### PR TITLE
[2117] Add validation to accept terms page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,12 @@ class UsersController < ApplicationController
   end
 
   def accept_terms
-    accept_screen('accept_terms', providers_path)
+    if params.require(:user)[:terms_accepted] == '1'
+      accept_screen('accept_terms', providers_path)
+    else
+      @errors = { user_terms_accepted: ['You must accept the terms and conditions to continue'] }
+      render file: 'pages/accept_terms'
+    end
   end
 
 private

--- a/app/views/pages/accept_terms.html.erb
+++ b/app/views/pages/accept_terms.html.erb
@@ -1,5 +1,7 @@
 <%= content_for :page_title, "Accept Terms and Conditions" %>
 
+<%= render 'shared/errors' %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Before you begin</h1>
@@ -17,7 +19,7 @@
     <%= form_for :user, url: accept_terms_path, method: :patch do |f| %>
       <div class="govuk-form-group">
         <div class="govuk-checkboxes">
-          <div class="govuk-checkboxes__item">
+          <div class="govuk-checkboxes__item" id="user_terms_accepted-error">
             <%= f.check_box :terms_accepted, class: 'govuk-checkboxes__input' %>
             <%= f.label :terms_accepted, "I agree to the terms and conditions", class: 'govuk-label govuk-checkboxes__label' %>
           </div>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -103,7 +103,7 @@ describe UsersController, type: :controller do
       end
 
       it "redirects to providers index" do
-        get :accept_terms
+        get :accept_terms, params: { user: { terms_accepted: "1" } }
         expect(response).to redirect_to(providers_path)
       end
     end
@@ -114,7 +114,7 @@ describe UsersController, type: :controller do
       end
 
       it "redirects to providers index" do
-        get :accept_terms
+        get :accept_terms, params: { user: { terms_accepted: "1" } }
         expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ClientError))
         expect(response).to redirect_to(providers_path)
       end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -123,6 +123,12 @@ feature 'Sign in', type: :feature do
     expect(accept_terms_page.title).to have_content('Before you begin')
     accept_terms_page.continue.click
 
+    expect(accept_terms_page).to be_displayed
+
+    expect(accept_terms_page).to have_content('You must accept the terms')
+    check('I agree to the terms and conditions')
+    accept_terms_page.continue.click
+
     expect(organisations_page).to be_displayed
     expect(request).to have_been_made
   end


### PR DESCRIPTION
### Context

We need to make sure that users check the checkbox before continuing.

### Changes proposed in this pull request

Adds validation in the controller.

### Guidance to review

:ship: