### PR TITLE
[2138] Redirect users on first sign in to accept T&Cs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,6 +67,7 @@ private
     user = Session.create(first_name: current_user_info[:first_name],
                           last_name: current_user_info[:last_name])
     session[:auth_user]['user_id'] = user.id
+    session[:auth_user]['state'] = user.state
 
     add_provider_count_cookie
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,13 +24,7 @@ class SessionsController < ApplicationController
     # current_user['user_id'] won't be set until set_user_session is run
     Raven.user_context(id: current_user['user_id'])
 
-    if user.state == 'new'
-      redirect_to transition_info_path
-    elsif Settings.rollover && user.state == 'transitioned'
-      redirect_to rollover_path
-    else
-      redirect_to session[:redirect_back_to] || root_path
-    end
+    redirect_to_correct_page(user)
   end
 
   def signout
@@ -54,5 +48,17 @@ private
 
   def auth_hash
     request.env["omniauth.auth"]
+  end
+
+  def redirect_to_correct_page(user)
+    if user.accept_terms_date_utc.nil?
+      redirect_to accept_terms_path
+    elsif user.state == 'new'
+      redirect_to transition_info_path
+    elsif Settings.rollover && user.state == 'transitioned'
+      redirect_to rollover_path
+    else
+      redirect_to session[:redirect_back_to] || root_path
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   def accept_terms
     if params.require(:user)[:terms_accepted] == '1'
-      accept_screen('accept_terms', providers_path)
+      accept_screen('accept_terms', page_after_accept_terms)
     else
       @errors = { user_terms_accepted: ['You must accept the terms and conditions to continue'] }
       render file: 'pages/accept_terms'
@@ -30,6 +30,17 @@ private
       redirect_to path
     else
       raise e
+    end
+  end
+
+  def page_after_accept_terms
+    case session[:auth_user]["state"]
+    when 'new'
+      transition_info_path
+    when 'transitioned'
+      rollover_path
+    else
+      session[:redirect_back_to] || root_path
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe ApplicationController, type: :controller do
           allow(Session).to receive(:create)
                               .with(first_name: user_info[:first_name],
                                     last_name: user_info[:last_name])
-                              .and_return(double(id: user_id))
+                              .and_return(double(id: user_id, state: "new"))
           allow(Provider).to receive_message_chain(:where, :all)
                                .and_return(%w[one two])
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -104,7 +104,7 @@ describe UsersController, type: :controller do
 
       it "redirects to providers index" do
         get :accept_terms, params: { user: { terms_accepted: "1" } }
-        expect(response).to redirect_to(providers_path)
+        expect(response).to redirect_to(root_path)
       end
     end
 
@@ -116,7 +116,7 @@ describe UsersController, type: :controller do
       it "redirects to providers index" do
         get :accept_terms, params: { user: { terms_accepted: "1" } }
         expect(Raven).to have_received(:capture_exception).with(instance_of(JsonApiClient::Errors::ClientError))
-        expect(response).to redirect_to(providers_path)
+        expect(response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
     trait :transitioned do
       state { 'transitioned' }
     end
+
+    trait :inactive do
+      accept_terms_date_utc { nil }
+    end
   end
 end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -97,9 +97,9 @@ feature 'Sign in', type: :feature do
     expect(request).to have_been_made
   end
 
-  scenario 'new user accepts the terms and conditions page with rollover disabled' do
+  scenario 'new inactive user accepts the terms and conditions page with rollover disabled' do
     allow(Settings).to receive(:rollover).and_return(false)
-    user = build :user, :transitioned
+    user = build :user, :inactive, :new
 
     stub_api_v2_request(
       "/recruitment_cycles/2019",
@@ -129,7 +129,7 @@ feature 'Sign in', type: :feature do
     check('I agree to the terms and conditions')
     accept_terms_page.continue.click
 
-    expect(organisations_page).to be_displayed
+    expect(transition_info_page).to be_displayed
     expect(request).to have_been_made
   end
 end


### PR DESCRIPTION
### Context

This should fix the current 403s we're seeing live.

### Changes proposed in this pull request

We store the user's initial transition state as part of the session, and decide as part of the sessions create where to initially send them.

We also need some additional plumbing to decide where to send users after they accept terms, whether it's directly to the app, to where they were initially going to, or to another screen.

### Guidance to review

We'll test this thoroughly on QA.