### PR TITLE
[xxx] Fixed the remainder of notification banner execution tags

### DIFF
--- a/app/views/courses/preview.html.erb
+++ b/app/views/courses/preview.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <%= govuk_notification_banner(title_text: t("notification_banner.info")) do |notification_banner| %>
-  <%= notification_banner.heading(text: "This is a preview of the ‘#{course.name_and_code}’ course.") %>
+  <% notification_banner.heading(text: "This is a preview of the ‘#{course.name_and_code}’ course.") %>
 <% end %>
 
 <h1 class="govuk-heading-xl">

--- a/app/views/sign_in/dfe_sign_in_is_down.html.erb
+++ b/app/views/sign_in/dfe_sign_in_is_down.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_notification_banner(title_text: t("notification_banner.info")) do |notification_banner| %>
-      <%= notification_banner.heading(text: "Temporary login") %>
+      <% notification_banner.heading(text: "Temporary login") %>
       <p class="govuk-body">DfE Sign-in is experiencing problems. You need to sign in using your email address.</p>
     <% end %>
 

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <% if Settings.features.maintenance_mode.enabled %>
       <%= govuk_notification_banner(title_text: t("notification_banner.info")) do |notification_banner| %>
-        <%= notification_banner.heading(text: Settings.features.maintenance_mode.title) %>
+        <% notification_banner.heading(text: Settings.features.maintenance_mode.title) %>
         <p class="govuk-body"><%= Settings.features.maintenance_mode.body %></p>
       <% end %>
     <% end %>


### PR DESCRIPTION
### Context

- Some left over double messages from excessive erb execution tags for notifications. 

### Changes proposed in this pull request

- Removed the execution tags to avoid the double message

### Guidance to review

- If DfE sign in is down, the message is not doubled
- If maintenence is happening, the message is not doubled
- If you preview the course on find, the message is not doubled

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
