### PR TITLE
[214] Added guard clause to stop withdrawn courses getting withdrawn

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -128,9 +128,10 @@ class CoursesController < ApplicationController
 
   def withdraw_course
     if request.post?
-      return redirect_to_relative_path if course_withdrawn?
-
-      if params[:course][:confirm_course_code] == @course.course_code
+      if course_withdrawn?
+        flash[:error] = { id: "withdraw-error", message: "#{@course.course_code} has already been withdrawn" }
+        redirect_to withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)
+      elsif params[:course][:confirm_course_code] == @course.course_code
         @course.withdraw
         redirect_to provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)
         flash[:success] = "#{@course.name} (#{@course.course_code}) has been withdrawn"
@@ -170,11 +171,6 @@ class CoursesController < ApplicationController
   end
 
 private
-
-  def redirect_to_relative_path
-    render template: "courses/withdraw"
-    flash[:error] = { id: "delete-error", message: "#{@course.name} (#{@course.course_code}) has already been withdrawn" }
-  end
 
   def course_withdrawn?
     @course.content_status == "withdrawn"

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -72,4 +72,25 @@ feature "Withdraw course", type: :feature do
       )
     end
   end
+
+  context "the course is already withdrawn" do
+    let(:course) do
+      build :course,
+            ucas_status: "running",
+            provider: provider,
+            recruitment_cycle: current_recruitment_cycle,
+            content_status: "withdrawn"
+    end
+
+    scenario "display validation errors" do
+      course_page.withdraw_link.click
+
+      fill_in "Type in the course code to confirm", with: "Z"
+      click_on "Yes I’m sure – withdraw this course"
+
+      expect(course_page.error_summary).to have_content(
+        "#{course.course_code} has already been withdrawn",
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/C7xzKvIl/214-bug-non-withdrawable-courses-being-able-to-be-withdrawn)

### Changes proposed in this pull request

- Guard clause added to return error message if the course has already been withdrawn

### Guidance to review

- Withdraw a course, and navigate back to the withdraw page (will have to append `/withdraw` onto the uri) and try to withdraw again. You are met with an error

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
