### PR TITLE
[xxx] Remove publish courses banner

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,12 +1,6 @@
 <% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
 
-<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find.</strong></span><br><br>
-
-  <span class="govuk-body">Do this by selecting your course, check and edit the details, then click the “Publish” button.</span>
-<% end %>
-
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
   Courses

--- a/app/views/providers/show.html.erb
+++ b/app/views/providers/show.html.erb
@@ -3,12 +3,6 @@
   <%= content_for :before_content, render_breadcrumbs(:provider) %>
 <% end %>
 
-<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find.</strong></span><br><br>
-
-  <span class="govuk-body">Do this by selecting your course, check and edit the details, then click the “Publish” button.</span>
-<% end %>
-
 <h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
 
 <div class="govuk-grid-row">

--- a/app/views/recruitment_cycles/show.html.erb
+++ b/app/views/recruitment_cycles/show.html.erb
@@ -1,12 +1,6 @@
 <% content_for :page_title, @recruitment_cycle.title %>
 <%= content_for :before_content, render_breadcrumbs(:recruitment_cycle) %>
 
-<%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important') do |notification_banner| %>
-  <span class="govuk-body"><strong>Publish your courses so that candidates can view them on Find.</strong></span><br><br>
-
-  <span class="govuk-body">Do this by selecting your course, check and edit the details, then click the “Publish” button.</span>
-<% end %>
-
 <h1 class="govuk-heading-l">
   <%= @recruitment_cycle.title %>
 </h1>


### PR DESCRIPTION
### Context

The cycle is open now. Normal service is resumed.

### Changes proposed in this pull request

Remove the banner prompting users to publish their courses.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
