### PR TITLE
[xxx] Invalid withdraw redirects to course page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -130,7 +130,7 @@ class CoursesController < ApplicationController
     if request.post?
       if course_withdrawn?
         flash[:error] = { id: "withdraw-error", message: "#{@course.course_code} has already been withdrawn" }
-        redirect_to withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)
+        redirect_to provider_recruitment_cycle_courses_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code)
       elsif params[:course][:confirm_course_code] == @course.course_code
         @course.withdraw
         redirect_to provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)

--- a/spec/features/courses/withdraw_spec.rb
+++ b/spec/features/courses/withdraw_spec.rb
@@ -11,6 +11,7 @@ feature "Withdraw course", type: :feature do
   end
 
   let(:course_page) { PageObjects::Page::Organisations::Course.new }
+  let(:courses_page) { PageObjects::Page::Organisations::CoursesPage.new }
 
   before do
     signed_in_user
@@ -27,6 +28,7 @@ feature "Withdraw course", type: :feature do
       200,
     )
 
+    courses_page.load(provider_code: provider.provider_code, recruitment_cycle_year: course.recruitment_cycle.year)
     course_page.load(provider_code: provider.provider_code, recruitment_cycle_year: course.recruitment_cycle.year, course_code: course.course_code)
   end
 
@@ -88,7 +90,7 @@ feature "Withdraw course", type: :feature do
       fill_in "Type in the course code to confirm", with: "Z"
       click_on "Yes I’m sure – withdraw this course"
 
-      expect(course_page.error_summary).to have_content(
+      expect(courses_page.error_summary).to have_content(
         "#{course.course_code} has already been withdrawn",
       )
     end

--- a/spec/site_prism/page_objects/page/organisations/courses_page.rb
+++ b/spec/site_prism/page_objects/page/organisations/courses_page.rb
@@ -10,6 +10,7 @@ module PageObjects
 
         element :flash, ".govuk-notification-banner--success"
         element :caption, ".govuk-caption-l"
+        element :error_summary, ".govuk-error-summary"
 
         element :course_create, ".govuk-button", text: "Add a new course"
         element :course_create_additional, '[data-qa="course-create-additional"]'


### PR DESCRIPTION
### Context

- Invalid withdraw redirects to courses page (not back to withdraw page)

### Changes proposed in this pull request

- Changed the redirect link

### Guidance to review

- Withdraw, click back button (or manually change the URL) and resubmit the form. You should be redirected to course page with the error message

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
