### PR TITLE
Add programme type to the csv export

### DIFF
--- a/app/controllers/training_providers_courses_controller.rb
+++ b/app/controllers/training_providers_courses_controller.rb
@@ -16,6 +16,7 @@ class TrainingProvidersCoursesController < ApplicationController
         "Course code" => c.course_code,
         "Course" => c.name,
         "Study mode" => c.study_mode&.humanize,
+        "Programme type" => c.program_type&.humanize,
         "Qualification" => c.outcome,
         "Status" => c.content_status&.humanize,
         "View on Find" => c.find_url,

--- a/spec/requests/providers_spec.rb
+++ b/spec/requests/providers_spec.rb
@@ -101,8 +101,8 @@ describe "Providers", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).to eq(
           <<~HEREDOC,
-            Provider code,Provider,Course code,Course,Study mode,Qualification,Status,View on Find,Applications open from,Vacancies
-            #{course.provider.provider_code},#{course.provider.provider_name},#{course.course_code},#{course.name},#{decorated_course.study_mode.humanize},#{decorated_course.outcome},#{course.content_status.humanize},#{decorated_course.find_url},#{I18n.l(course.applications_open_from.to_date)},No
+            Provider code,Provider,Course code,Course,Study mode,Programme type,Qualification,Status,View on Find,Applications open from,Vacancies
+            #{course.provider.provider_code},#{course.provider.provider_name},#{course.course_code},#{course.name},#{decorated_course.study_mode.humanize},#{decorated_course.program_type.humanize},#{decorated_course.outcome},#{course.content_status.humanize},#{decorated_course.find_url},#{I18n.l(course.applications_open_from.to_date)},No
           HEREDOC
         )
       end


### PR DESCRIPTION
### Context

- Accrediting providers requested that program type be included in the csv export for courses that they accredit

### Changes proposed in this pull request

- Add program type from course object to csv export

### Guidance to review

- On an accrediting provider, click on the `Courses as an accrediting body` and click on the download as a CSV file. You will see the column for programme type, populated. 

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product Review
