### PR TITLE
[105] Check UKPRN present when providers visit their details page

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -26,6 +26,8 @@ class ProvidersController < ApplicationController
   end
 
   def details
+    redirect_to_contact_page_with_ukprn_error if @provider.ukprn.blank?
+
     @errors = flash[:error_summary]
     flash.delete(:error_summary)
   end
@@ -175,5 +177,11 @@ private
 
   def providers
     @providers ||= Provider.where(recruitment_cycle_year: Settings.current_cycle)
+  end
+
+  def redirect_to_contact_page_with_ukprn_error
+    flash[:error] = { id: "provider-error", message: "Please enter a UKPRN before continuing" }
+
+    redirect_to contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
   end
 end

--- a/spec/features/providers/details_spec.rb
+++ b/spec/features/providers/details_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "View provider", type: :feature do
   let(:org_detail_page) { PageObjects::Page::Organisations::OrganisationDetails.new }
+  let(:org_contact_page) { PageObjects::Page::Organisations::OrganisationContact.new }
 
   before do
     allow(Settings.features.rollover).to receive(:has_current_cycle_started?).and_return(true)
@@ -82,6 +83,15 @@ feature "View provider", type: :feature do
     if FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
       expect(breadcrumbs[1].text).to eq(provider.recruitment_cycle.title)
       expect(breadcrumbs[1]["href"]).to eq("/organisations/#{provider.provider_code}/#{provider.recruitment_cycle.year}")
+    end
+  end
+
+  context "when a provider doesnt have a UKPRN" do
+    let(:provider) { build(:provider, ukprn: nil) }
+
+    it "redirects the provider to their contact's page with a validation message" do
+      expect(current_path).to eq contact_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle.year)
+      expect(org_contact_page.error_flash).to have_content("Please enter a UKPRN before continuing")
     end
   end
 end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/ZDdxEZVg/105-bug-if-provider-does-not-have-urn-ukprn-visa-sponsorship-form-does-not-submit)
- Providers were getting insufficient error messages as a mismatch of form objects didnt allow a bigger enough error scope

### Changes proposed in this pull request

- As a provider without a UKPRN is invalid and cant make changes, a redirect to their UKPRN form is set up when they visit their "details" page
- Redirect to UKPRN form if provider visits their details page without a UKPRN

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product Review
